### PR TITLE
product normalize

### DIFF
--- a/framework/common/types/product.ts
+++ b/framework/common/types/product.ts
@@ -1,0 +1,13 @@
+export interface ProductImage {
+  url: string;
+  alt?: string;
+}
+
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  slug: string;
+  path: string;
+  images: ProductImage[];
+}

--- a/framework/shopify/product/get-all-product.ts
+++ b/framework/shopify/product/get-all-product.ts
@@ -1,6 +1,8 @@
 import fetchApi from "../utils/fetch-api";
 import getAllProductsQuery from "../utils/queries/get-all-product";
+import { normalizeProduct } from "../utils/normalize";
 import { ProductConnection } from "../schema";
+import { Product } from "../../common/types/product";
 
 // products情報を取得するタイプを宣言
 type ReturnType = {
@@ -8,12 +10,18 @@ type ReturnType = {
 };
 
 // fetchApiで取得したデータをProductのデータとして返す関数
-const getAllProducts = async (): Promise<any> => {
+const getAllProducts = async (): Promise<Product[]> => {
   // data = ReturnType
   const { data } = await fetchApi<ReturnType>({ query: getAllProductsQuery });
 
-  // normalize and return new data!
-  return data.products;
+  // products nodeを参照するproducts変数を宣言
+  // null or undefindの場合はから配列を返す
+  const products: any =
+    data.products.edges.map(({ node: product }) => {
+      normalizeProduct(product);
+    }) ?? [];
+
+  return products;
 };
 
 export default getAllProducts;

--- a/framework/shopify/utils/normalize.ts
+++ b/framework/shopify/utils/normalize.ts
@@ -1,0 +1,35 @@
+import { ImageEdge, Product as ShopifyProduct } from "../schema";
+import { Product } from "../../common/types/product";
+
+// ImageEdge配列のedgesタイプの引数を受け取り、ImageEdgeの情報から、URLをnormalize化した値を返す
+const normalizeProductImages = ({ edges }: { edges: Array<ImageEdge> }) =>
+  edges.map(({ node: { originalSrc: url, ...rest } }) => ({
+    url: `/images/${url}`,
+    ...rest,
+  }));
+
+// GraphQLからProduct情報を取得して自身のEC用の情報としてノーマライズ化する関数を定義
+export function normalizeProduct(productNode: ShopifyProduct): Product {
+  const {
+    id,
+    title: name,
+    handle,
+    vendor,
+    description,
+    images: imageConnection,
+    ...rest
+  } = productNode;
+
+  const product = {
+    id,
+    name,
+    vendor,
+    description,
+    path: `/${handle}`,
+    slug: handle.replace(/^\/+|\/+$/g, ""),
+    images: normalizeProductImages(imageConnection),
+    ...rest,
+  };
+
+  return product;
+}


### PR DESCRIPTION
```
// fetchApiで取得したデータをProductのデータとして返す関数
const getAllProducts = async (): Promise<Product[]> => {
  // data = ReturnType
  const { data } = await fetchApi<ReturnType>({ query: getAllProductsQuery });

  // products nodeを参照するproducts変数を宣言
  // null or undefindの場合はから配列を返す
  const products: any =
    data.products.edges.map(({ node: product }) => {
      normalizeProduct(product);
    }) ?? [];

  return products;
};
```


以下定数の型を指定しないとエラーが発生するので一旦any型に設定しといた。
demoでは `Promise<Product[]>` で配列指定すればいけたのだが、、

`const products: any =`